### PR TITLE
Derringer buff

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -376,6 +376,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/pistol/superheavy/derringer
 	handful_amount = 2
 	handful_icon_state = "derringer"
+	
+/datum/ammo/bullet/pistol/superheavy/derringer/on_hit_mob(mob/M,obj/projectile/P)
+	staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)
 
 /datum/ammo/bullet/pistol/mech
 	name = "super-heavy pistol bullet"


### PR DESCRIPTION
## About The Pull Request

I have returned from my short trip to LV246; it was an extraordinary place, although I briefly syncopated in a botanical garden in which various xenomorphs kept looking at me strangely. Deciding to return to more civilized locales, I felt compelled to at least teach one of these ruffians a lesson about staring. I was, of course, unprepared for what would accost my eyes when I was set to use my derringer in a proper show of force to collar the red-tinged varlet on my tail. But alas, I held firm and shot at the alien foe - glaring in horror as he stood in place, not moving but an inch! 

It felt properly unsporting, later watching him be carried away on a Fulton, my weapon of choice fully useless in the thick haze of combat - as if I was a valitard during a fit of unga, or some other form of knave with an air for subterfuge instead of force projection and proper application of kinetic energy.

## Why It's Good For The Game

The scathingly spare cretins known to all as the coderbus shall no-longer dictate the rules at which we apply ourselves. The Derringer has received an upgrade, allowing it to somewhat fulfill the purpose of a "fuck off" weapon. To the few who may think this change is too much, I encourage you to attempt to use the derringer yourself. It is currently quite shit.

## Changelog
:cl:
balance: Derringer now applies knockback and slowdown.
/:cl: